### PR TITLE
Test FadeInOut animator

### DIFF
--- a/CCHMapClusterController Example iOS/CCHMapClusterController Example iOS.xcodeproj/project.pbxproj
+++ b/CCHMapClusterController Example iOS/CCHMapClusterController Example iOS.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		62D667D21845F8A40046D5D5 /* CCHMapClusterControllerUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 62D667CB1845F8A40046D5D5 /* CCHMapClusterControllerUtils.m */; };
 		62D667D41845F8A40046D5D5 /* CCHMapViewDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 62D667CD1845F8A40046D5D5 /* CCHMapViewDelegateProxy.m */; };
 		62D71E11187EB45500E52EE3 /* ClusterAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 62D71E10187EB45500E52EE3 /* ClusterAnnotationView.m */; };
+		8A3EB24E18A9B8C400605363 /* CCHFadeInOutMapAnimatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EB24D18A9B8C400605363 /* CCHFadeInOutMapAnimatorTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -128,6 +129,7 @@
 		62D667CD1845F8A40046D5D5 /* CCHMapViewDelegateProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCHMapViewDelegateProxy.m; sourceTree = "<group>"; };
 		62D71E0F187EB45500E52EE3 /* ClusterAnnotationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ClusterAnnotationView.h; sourceTree = "<group>"; };
 		62D71E10187EB45500E52EE3 /* ClusterAnnotationView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ClusterAnnotationView.m; sourceTree = "<group>"; };
+		8A3EB24D18A9B8C400605363 /* CCHFadeInOutMapAnimatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CCHFadeInOutMapAnimatorTests.m; path = "../../CCHMapClusterController Tests/CCHFadeInOutMapAnimatorTests.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -270,6 +272,7 @@
 				48899967185F875600F3D6ED /* CCHMapClusterControllerTests.m */,
 				62978DDE1859D57F00748230 /* CCHMapClusterControllerPerformanceTests.m */,
 				4889995E185D1D9300F3D6ED /* CCHMapTreeTests.m */,
+				8A3EB24D18A9B8C400605363 /* CCHFadeInOutMapAnimatorTests.m */,
 				62D667A81845E0F20046D5D5 /* Supporting Files */,
 			);
 			path = "CCHMapClusterController Example iOSTests";
@@ -436,6 +439,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8A3EB24E18A9B8C400605363 /* CCHFadeInOutMapAnimatorTests.m in Sources */,
 				48D7B0CF185BA3750071636B /* TBQuadTree.m in Sources */,
 				48899957185CE2B000F3D6ED /* QTreeGeometryUtils.m in Sources */,
 				4889995A185D175000F3D6ED /* QCluster.m in Sources */,

--- a/CCHMapClusterController Tests/CCHFadeInOutMapAnimatorTests.m
+++ b/CCHMapClusterController Tests/CCHFadeInOutMapAnimatorTests.m
@@ -1,0 +1,94 @@
+//
+//  CCHFadeInOutMapAnimatorTests.m
+//  CCHMapClusterController Example iOS
+//
+//  Created by Claus on 16.12.13.
+//  Copyright (c) 2013 Claus Höfele. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CCHMapClusterController.h"
+#import "CCHMapClusterAnnotation.h"
+#import "CCHMapClusterControllerUtils.h"
+#import "CCHFadeInOutMapAnimator.h"
+
+@interface CCHFadeInOutMapAnimatorTests : XCTestCase
+
+@property (nonatomic, strong) MKMapView *mapView;
+@property (nonatomic, strong) CCHMapClusterController *mapClusterController;
+@property (nonatomic, strong) CCHFadeInOutMapAnimator *animator;
+@property (nonatomic, assign) BOOL done;
+
+@end
+
+@implementation CCHFadeInOutMapAnimatorTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    self.mapView = [[MKMapView alloc] initWithFrame:CGRectMake(0, 0, 300, 300)];
+    self.mapClusterController = [[CCHMapClusterController alloc] initWithMapView:self.mapView];
+    self.animator = [[CCHFadeInOutMapAnimator alloc] init];
+    self.mapClusterController.animator = _animator;
+    self.done = NO;
+}
+
+- (BOOL)waitForCompletion:(NSTimeInterval)timeoutSecs
+{
+    NSDate *timeoutDate = [NSDate dateWithTimeIntervalSinceNow:timeoutSecs];
+    
+    do {
+        [NSRunLoop.currentRunLoop runMode:NSDefaultRunLoopMode beforeDate:timeoutDate];
+        if (timeoutDate.timeIntervalSinceNow < 0.0) {
+            break;
+        }
+    } while (!self.done);
+    
+    return self.done;
+}
+
+- (void)testFadeInOut
+{
+    MKPointAnnotation *annotation = [[MKPointAnnotation alloc] init];
+    annotation.coordinate = CLLocationCoordinate2DMake(52.5, 13.5);
+    MKCoordinateRegion region = MKCoordinateRegionMake(annotation.coordinate, MKCoordinateSpanMake(3, 3));
+    self.mapView.region = region;
+    
+    __weak CCHFadeInOutMapAnimatorTests *weakSelf = self;
+    [self.mapClusterController addAnnotations:@[annotation] withCompletionHandler:^{
+        weakSelf.done = YES;
+    }];
+    XCTAssertTrue([self waitForCompletion:1.0], @"Time out");
+    XCTAssertEqual(self.mapView.annotations.count, (NSUInteger)1, @"Wrong number of annotations");
+
+    // Get the cluster UIView
+    NSSet *annotationsInMapRect = [self.mapView annotationsInMapRect:self.mapView.visibleMapRect];
+    XCTAssertEqual(annotationsInMapRect.count, (NSUInteger)1, @"Wrong number of annotations");
+
+    CCHMapClusterAnnotation *clusterAnnotation = (CCHMapClusterAnnotation *)annotationsInMapRect.anyObject;
+    UIView *clusterView = [self.mapView viewForAnnotation:clusterAnnotation];
+    
+    XCTAssert(clusterAnnotation, @"Expected a cluster");
+    XCTAssert(clusterView, @"Expected a view");
+    XCTAssertEqualWithAccuracy(clusterView.alpha, 1.0, __FLT_EPSILON__, @"Wrong alpha");
+    
+    // Fade Out
+    self.done = NO;
+    [self.mapClusterController removeAnnotations:@[annotation] withCompletionHandler:^{
+        weakSelf.done = YES;
+    }];
+    XCTAssertTrue([self waitForCompletion:1.0], @"Time out");
+    XCTAssertEqualWithAccuracy(clusterView.alpha, 0.0, __FLT_EPSILON__, @"Wrong alpha");
+
+    // Fade In
+    self.done = NO;
+    [self.mapClusterController addAnnotations:@[annotation] withCompletionHandler:^{
+        weakSelf.done = YES;
+    }];
+    XCTAssertTrue([self waitForCompletion:1.0], @"Time out");
+    XCTAssertEqualWithAccuracy(clusterView.alpha, 1.0, __FLT_EPSILON__, @"Wrong alpha");
+}
+
+@end


### PR DESCRIPTION
This is the first test for FadeInOut animator, for simplicity I basically cloned testAddAnnotationsSimple.
Since the alpha animation itself can not be tested I just check the ending alpha value. Just a note: after adding and testing the annotation alpha I keep a reference to the UIView so I can remove the annotation and still test the alpha value. Once the annotation is added again I still check the very same UIView .. now this could be wrong, because I don't think its guaranteed anywhere in MapView that it would reuse it. Anyway this is a first step :) 
