### PR TITLE
Annotations are not deselected when heading changes

### DIFF
--- a/CCHMapClusterController/CCHMapClusterController.m
+++ b/CCHMapClusterController/CCHMapClusterController.m
@@ -294,7 +294,8 @@
     
     // Deselect all annotations when zooming in/out.
     BOOL hasZoomed;
-    if ([mapView respondsToSelector:@selector(camera)]) {
+    if (mapView.userTrackingMode == MKUserTrackingModeFollowWithHeading && [mapView respondsToSelector:@selector(camera)])
+    {
         hasZoomed = !fequal(mapView.camera.altitude, self.mapCameraAltitudeBeforeRegionChange);
     }
     else {


### PR DESCRIPTION
Zoom is detected by camera altitude in order not to deselect annotations at each compass update. On iOS 6 this behavior is still not correct.
