### PR TITLE
Added Function to Remove All Annotations of CCHMapClusterController

### DIFF
--- a/CCHMapClusterController/CCHMapClusterController.h
+++ b/CCHMapClusterController/CCHMapClusterController.h
@@ -89,6 +89,12 @@
  */
 - (void)removeAnnotations:(NSArray *)annotations withCompletionHandler:(void (^)())completionHandler;
 
+/**
+ Removes All annotations and immediately updates clustering.
+ @param completionHandler Called when the clustering finished updating.
+ */
+- (void)removeAllAnnotationswithCompletionHandler:(void (^)())completionHandler;
+
 /** 
  Zooms to the position of the cluster that contains the given annotation and selects the cluster's annotation view.
  @param annotation The annotation to look for. Uses `isEqual:` to check for a matching annotation previously added with `addAnnotations:withCompletionHandler:`.

--- a/CCHMapClusterController/CCHMapClusterController.m
+++ b/CCHMapClusterController/CCHMapClusterController.m
@@ -169,6 +169,24 @@
     }];
 }
 
+- (void)removeAllAnnotationswithCompletionHandler:(void (^)())completionHandler{
+    [self cancelAllClusterOperations];
+    
+    NSArray* annotations = [self.allAnnotations allObjects];
+    [self.allAnnotations removeAllObjects];
+    
+    [self.backgroundQueue addOperationWithBlock:^{
+        BOOL updated = [self.allAnnotationsMapTree removeAnnotations:annotations];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (updated && !self.isRegionChanging) {
+                [self updateAnnotationsWithCompletionHandler:completionHandler];
+            } else if (completionHandler) {
+                completionHandler();
+            }
+        });
+    }];
+}
+
 - (void)updateAnnotationsWithCompletionHandler:(void (^)())completionHandler
 {
     [self cancelAllClusterOperations];


### PR DESCRIPTION
Because of the difference between collection types of Swift and
Objective-C, it was hard to remove all annotations from
CCHMapClusterController with removeAnnotation function.
This will be only a little useful function for Swift users.