### PR TITLE
Allow Annotations with Same Coordinates to Uncluster

### DIFF
--- a/CCHMapClusterController Tests/CCHMapClusterControllerTests.m
+++ b/CCHMapClusterController Tests/CCHMapClusterControllerTests.m
@@ -316,7 +316,7 @@
         [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:10 handler:NULL];
-    XCTAssertEqual(self.mapView.annotations.count, 2);
+    XCTAssertEqual(self.mapView.annotations.count, 3);
 }
 
 - (void)testAddAnnotationsMinUniqueLocationsEnableClustering
@@ -366,7 +366,7 @@
         [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:10 handler:NULL];
-    XCTAssertEqual(self.mapView.annotations.count, 2);
+    XCTAssertEqual(self.mapView.annotations.count, 1);
 }
 
 #if TARGET_OS_IPHONE

--- a/CCHMapClusterController Tests/CCHMapClusterControllerUtilsTests.m
+++ b/CCHMapClusterController Tests/CCHMapClusterControllerUtilsTests.m
@@ -348,8 +348,8 @@
     NSSet *annotations = [NSSet setWithArray:@[annotation0, annotation1]];
     NSArray *uniqueAnnotations = CCHMapClusterControllerAnnotationSetsByUniqueLocations(annotations, NSUIntegerMax);
     
-    XCTAssertEqual(uniqueAnnotations.count, 1);
-    XCTAssertEqual([uniqueAnnotations[0] count], 2);
+    XCTAssertEqual(uniqueAnnotations.count, 2);
+    XCTAssertEqual([uniqueAnnotations[0] count], 1);
 }
 
 - (void)testAnnotationsByUniqueLocationsClose
@@ -362,8 +362,8 @@
     NSSet *annotations = [NSSet setWithArray:@[annotation0, annotation1]];
     NSArray *uniqueAnnotations = CCHMapClusterControllerAnnotationSetsByUniqueLocations(annotations, NSUIntegerMax);
     
-    XCTAssertEqual(uniqueAnnotations.count, 1);
-    XCTAssertEqual([uniqueAnnotations[0] count], 2);
+    XCTAssertEqual(uniqueAnnotations.count, 2);
+    XCTAssertEqual([uniqueAnnotations[0] count], 1);
 }
 
 - (void)testAnnotationsByUniqueLocationsTwoLocations

--- a/CCHMapClusterController/CCHMapClusterControllerUtils.m
+++ b/CCHMapClusterController/CCHMapClusterControllerUtils.m
@@ -281,30 +281,18 @@ static NSString *hashForCoordinate(CLLocationCoordinate2D coordinate, NSUInteger
 
 NSArray *CCHMapClusterControllerAnnotationSetsByUniqueLocations(NSSet *annotations, NSUInteger maxUniqueLocations)
 {
-    NSMutableDictionary *annotationsByGeohash;
-    
-    if (maxUniqueLocations > 0) {
-        annotationsByGeohash = [NSMutableDictionary dictionary];
-        
-        for (id<MKAnnotation> annotation in annotations) {
-            // Add annotation to unique locations
-            NSString *geohash = hashForCoordinate(annotation.coordinate, GEOHASH_LENGTH);
-            NSMutableSet *annotationsAtLocation = [annotationsByGeohash objectForKey:geohash];
-            if (!annotationsAtLocation) {
-                annotationsAtLocation = [NSMutableSet set];
-            }
-            [annotationsAtLocation addObject:annotation];
-            [annotationsByGeohash setObject:annotationsAtLocation forKey:geohash];
-            
-            // Return nil if max has been reached
-            if (annotationsByGeohash.count > maxUniqueLocations) {
-                annotationsByGeohash = nil;
-                break;
-            }
-        }
+    // Return nil if max has been reached.
+    if (annotations.count > maxUniqueLocations) {
+        return nil;
     }
     
-    return [annotationsByGeohash allValues];
+    NSMutableArray *arrayOfSets = [[NSMutableArray alloc] init];
+    for (id<MKAnnotation> annotation in annotations) {
+        NSSet *set = [[NSSet alloc] initWithArray:@[annotation]];
+        [arrayOfSets addObject:set];
+    }
+    
+    return [arrayOfSets copy];
 }
 
 BOOL CCHMapClusterControllerIsUniqueLocation(NSSet *annotations)


### PR DESCRIPTION
Thanks for your work on this clustering library!

Annotations with the same coordinates were never un-clustering (and as a result could never be selected individually). They remained clustered even at max zoom and in spite of min unique locations and max zoom level settings.