### PR TITLE
Fixed race condition with calculation for left and right coordinates …

### DIFF
--- a/CCHMapClusterController/CCHMapClusterControllerUtils.h
+++ b/CCHMapClusterController/CCHMapClusterControllerUtils.h
@@ -31,11 +31,7 @@
 
 MKMapRect CCHMapClusterControllerAlignMapRectToCellSize(MKMapRect mapRect, double cellSize);
 CCHMapClusterAnnotation *CCHMapClusterControllerFindVisibleAnnotation(NSSet *annotations, NSSet *visibleAnnotations);
-#if TARGET_OS_IPHONE
-double CCHMapClusterControllerMapLengthForLength(MKMapView *mapView, UIView *view, double length);
-#else
-double CCHMapClusterControllerMapLengthForLength(MKMapView *mapView, NSView *view, double length);
-#endif
+double CCHMapClusterControllerMapLengthForLength(MKMapView *mapView, double length);
 double CCHMapClusterControllerAlignMapLengthToWorldWidth(double mapLength);
 BOOL CCHMapClusterControllerCoordinateEqualToCoordinate(CLLocationCoordinate2D coordinate0, CLLocationCoordinate2D coordinate1);
 CCHMapClusterAnnotation *CCHMapClusterControllerClusterAnnotationForAnnotation(MKMapView *mapView, id<MKAnnotation> annotation, MKMapRect mapRect);

--- a/CCHMapClusterController/CCHMapClusterControllerUtils.m
+++ b/CCHMapClusterController/CCHMapClusterControllerUtils.m
@@ -59,15 +59,11 @@ CCHMapClusterAnnotation *CCHMapClusterControllerFindVisibleAnnotation(NSSet *ann
     return nil;
 }
 
-#if TARGET_OS_IPHONE
-double CCHMapClusterControllerMapLengthForLength(MKMapView *mapView, UIView *view, double length)
-#else
-double CCHMapClusterControllerMapLengthForLength(MKMapView *mapView, NSView *view, double length)
-#endif
+double CCHMapClusterControllerMapLengthForLength(MKMapView *mapView, double length)
 {
     // Convert points to coordinates
-    CLLocationCoordinate2D leftCoordinate = [mapView convertPoint:CGPointZero toCoordinateFromView:view];
-    CLLocationCoordinate2D rightCoordinate = [mapView convertPoint:CGPointMake(length, 0) toCoordinateFromView:view];
+    CLLocationCoordinate2D leftCoordinate = [mapView convertPoint:CGPointZero toCoordinateFromView:mapView];
+    CLLocationCoordinate2D rightCoordinate = [mapView convertPoint:CGPointMake(length, 0) toCoordinateFromView:mapView];
     
     // Convert coordinates to map points
     MKMapPoint leftMapPoint = MKMapPointForCoordinate(leftCoordinate);

--- a/CCHMapClusterController/CCHMapClusterOperation.m
+++ b/CCHMapClusterController/CCHMapClusterOperation.m
@@ -82,7 +82,7 @@
 + (double)cellMapSizeForCellSize:(double)cellSize withMapView:(MKMapView *)mapView
 {
     // World size is multiple of cell size so that cells wrap around at the 180th meridian
-    double cellMapSize = CCHMapClusterControllerMapLengthForLength(mapView, mapView.superview, cellSize);
+    double cellMapSize = CCHMapClusterControllerMapLengthForLength(mapView, cellSize);
     cellMapSize = CCHMapClusterControllerAlignMapLengthToWorldWidth(cellMapSize);
     
     return cellMapSize;


### PR DESCRIPTION
…of map view to calculate length

This caused the cell size sometimes to be 0 due to a race condition when converting coordinates from the map view to its super view. When that happened, all annotations become invisible. This constantly happens when rotating, especially in flyover mode.
Instead we are now calculating it against its own view, which always returns consistent and valid results.