### PR TITLE
Explicitly reference self in blocks.

### DIFF
--- a/CCHMapClusterController/CCHMapClusterOperation.m
+++ b/CCHMapClusterController/CCHMapClusterOperation.m
@@ -109,7 +109,7 @@
     MKMapRect gridMapRect = [self.class gridMapRectForMapRect:self.mapViewVisibleMapRect withCellMapSize:self.cellMapSize marginFactor:self.marginFactor];
     NSMutableSet *clusters = [NSMutableSet set];
     CCHMapClusterControllerEnumerateCells(gridMapRect, _cellMapSize, ^(MKMapRect cellMapRect) {
-        NSSet *allAnnotationsInCell = [_allAnnotationsMapTree annotationsInMapRect:cellMapRect];
+        NSSet *allAnnotationsInCell = [self->_allAnnotationsMapTree annotationsInMapRect:cellMapRect];
         
         if (allAnnotationsInCell.count > 0) {
             BOOL annotationSetsAreUniqueLocations;
@@ -119,7 +119,7 @@
                 annotationSets = CCHMapClusterControllerAnnotationSetsByUniqueLocations(allAnnotationsInCell, NSUIntegerMax);
                 annotationSetsAreUniqueLocations = YES;
             } else {
-                NSUInteger max = _minUniqueLocationsForClustering > 1 ? _minUniqueLocationsForClustering - 1 : 1;
+                NSUInteger max = self->_minUniqueLocationsForClustering > 1 ? self->_minUniqueLocationsForClustering - 1 : 1;
                 annotationSets = CCHMapClusterControllerAnnotationSetsByUniqueLocations(allAnnotationsInCell, max);
                 if (annotationSets) {
                     // Create annotation for each unique location because there are too few locations for clustering
@@ -131,17 +131,17 @@
                 }
             }
 
-            NSMutableSet *visibleAnnotationsInCell = [NSMutableSet setWithSet:[_visibleAnnotationsMapTree annotationsInMapRect:cellMapRect]];
+            NSMutableSet *visibleAnnotationsInCell = [NSMutableSet setWithSet:[self->_visibleAnnotationsMapTree annotationsInMapRect:cellMapRect]];
             for (NSSet *annotationSet in annotationSets) {
                 CLLocationCoordinate2D coordinate;
                 if (annotationSetsAreUniqueLocations) {
                     coordinate = [annotationSet.anyObject coordinate];
                 } else {
-                    coordinate = [_clusterer mapClusterController:_clusterController coordinateForAnnotations:annotationSet inMapRect:cellMapRect];
+                    coordinate = [self->_clusterer mapClusterController:self->_clusterController coordinateForAnnotations:annotationSet inMapRect:cellMapRect];
                 }
                 
                 CCHMapClusterAnnotation *annotationForCell;
-                if (_reuseExistingClusterAnnotations) {
+                if (self->_reuseExistingClusterAnnotations) {
                     // Check if an existing cluster annotation can be reused
                     annotationForCell = CCHMapClusterControllerFindVisibleAnnotation(annotationSet, visibleAnnotationsInCell);
                     
@@ -155,8 +155,8 @@
                 if (annotationForCell == nil) {
                     // Create new cluster annotation
                     annotationForCell = [[CCHMapClusterAnnotation alloc] init];
-                    annotationForCell.mapClusterController = _clusterController;
-                    annotationForCell.delegate = _clusterControllerDelegate;
+                    annotationForCell.mapClusterController = self->_clusterController;
+                    annotationForCell.delegate = self->_clusterControllerDelegate;
                     annotationForCell.annotations = annotationSet;
                     annotationForCell.coordinate = coordinate;
                 } else {
@@ -170,7 +170,7 @@
                         annotationForCell.title = nil;
                         annotationForCell.subtitle = nil;
                         if (respondsToSelector) {
-                            [_clusterControllerDelegate mapClusterController:_clusterController willReuseMapClusterAnnotation:annotationForCell];
+                            [self->_clusterControllerDelegate mapClusterController:self->_clusterController willReuseMapClusterAnnotation:annotationForCell];
                         }
                     });
                 }


### PR DESCRIPTION
Hi there,

We are seeing build warnings with CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF set. This change is just to explicitly use self in a few blocks -- I have not changed the project file.

Thanks,
Gareth.